### PR TITLE
change helper from home to product template

### DIFF
--- a/fitgirls.js
+++ b/fitgirls.js
@@ -28,13 +28,14 @@
 			Template.home.helpers({
 			  	products: function () {
 			  		return Products.find({});
-			  	},
-			  	image:function(){ 
-					return console.log(productImages.findOne({'metadata.productId':this._id})); 
-					//return productImages.findOne({'metadata.productId':this._id})
 			  	}
 			});
-
+            Template.product.helpers({
+           image:function(){ 
+					 console.log(productImages.findOne({'metadata.productId':this._id})); 
+					return productImages.findOne({'metadata.productId':this._id})
+			  	}
+            })
 
 			  Template.add.helpers({
 			  	categories: function(){


### PR DESCRIPTION
Changing 

``` javascript
Template.home.helpers({
                products: function () {
                    return Products.find({});
                },
                                     image:function(){ 
                     console.log(productImages.findOne({'metadata.productId':this._id})); 
                    return productImages.findOne({'metadata.productId':this._id})
                }
            });
```

To.

``` javascript
Template.home.helpers({
                products: function () {
                    return Products.find({});
                }
            });

            Template.product.helpers({
           image:function(){ 
                     console.log(productImages.findOne({'metadata.productId':this._id})); 
                    return productImages.findOne({'metadata.productId':this._id})
                }
            })
```

Because you are calling the `images` helper on that template.

Here is an image of the Demo Working

![Example Of Demo Working](http://s24.postimg.org/g7yxlzax1/Captura_de_pantalla_2015_05_04_a_la_s_15_35_17.png)

**NOTE** if you don't know how to merge this PR check the [Mergin a Pull Request Documentation](https://help.github.com/articles/merging-a-pull-request/)
